### PR TITLE
add missing aspectj dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
 			<version>1.7.6</version>
 		</dependency>
 		<dependency>
+			<groupId>aspectj</groupId>
+		  	<artifactId>aspectjrt</artifactId>
+			<version>1.5.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.log4j</groupId>
 			<artifactId>com.springsource.org.apache.log4j</artifactId>
 			<version>1.2.15</version>


### PR DESCRIPTION
fixes build errors that I have had eg.

>[ERROR] org.geppetto.persistence/src/main/java/org/geppetto/persistence/db/BundleClassLoaderAspect.java[60,48] cannot access org.aspectj.lang.ProceedingJoinPoint
    class file for org.aspectj.lang.ProceedingJoinPoint ...

